### PR TITLE
Implement save playlist feature

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -28,6 +28,8 @@ app.get('/callback', authController.callback)
 
 app.get('/refresh_token', authController.refreshToken)
 
+app.post('/playlist/save', authController.savePlaylist)
+
 app.post('/playlist/generate', apiController.generatePlaylist)
 
 console.log('Listening on 8888')


### PR DESCRIPTION
# Save Playlist

## Changes made

- add `/playlist/save` route in `server/app.js`
- implement `savePlaylist` function in `server/authController.js`

## How does the solution address the problem

This PR will allow the backend to save a playlist to the user's Spotify library

## Testing the code with Postman
1. In `server/authController.js`, comment out this line in the `savePlaylist` function: `res.redirect('/login')`
2. Start the server with `node app.js`
3. Press the button that says "Log in with Spotify"
4. Open Postman, make a POST request to this route: `http://localhost:8888/playlist/save`
5. The request body should be something like the following: `{
  "name": "Test Playlist",
  "description": "Test playlist description",
  "track_uris": ["spotify:track:1EzaEQ1hUWj7NWphY5Allw"]
}`
6. The request header should have the following key-value pair: `Content-Type: application/json`
7. Go to your Spotify library to verify that the playlist is created properly


## Test Results
<img width="1440" alt="Screenshot 2023-02-25 at 7 08 27 PM" src="https://user-images.githubusercontent.com/61100042/221390148-5ad0acab-1cc1-40f6-9994-8a6ff17d2b90.png">
<img width="1440" alt="Screenshot 2023-02-25 at 7 09 42 PM" src="https://user-images.githubusercontent.com/61100042/221390168-01241a8c-4dc9-4b0c-8d7c-7b3adb7bd3d8.png">



## Linked Issues
Resolves #12
